### PR TITLE
Inline mock data for MomentSwap tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+.env
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# wan-tongyi-app
+# MomentSwap
+
+MomentSwap 是一个面向概念验证的最小可行产品（MVP），用于演示 [Wan-AI/Wan2.2-Animate](https://huggingface.co/spaces/Wan-AI/Wan2.2-Animate) 模型在短视频人物面部替换方面的能力。应用提供上传、进度反馈、结果预览与下载等核心体验。
+
+## 功能特性
+
+- 📤 上传目标面孔图片与源视频并即时预览。
+- 🚀 一键触发 Hugging Face 推理流程，并显示处理状态。
+- 🎬 在页面中播放最终生成的视频并支持下载。
+- 🔐 通过后端代理隐藏 API 密钥，避免前端泄露。
+- 🧪 覆盖单元测试与端到端（E2E）测试，确保基础逻辑可靠。
+
+## 快速开始
+
+> **注意**：默认情况下应用运行在 *Mock 模式*，用于本地开发与自动化测试。
+> 若要调用真实的 Wan-AI 模型，请提供有效的 Hugging Face Token。
+
+```bash
+# 启动开发服务器（默认端口 3000）
+npm run dev
+
+# 运行单元测试
+npm test
+
+# 运行端到端测试（自动启用 Mock 模式）
+npm run test:e2e
+
+# 运行全部测试套件
+npm run test:all
+```
+
+访问 <http://localhost:3000> 即可体验。
+
+## 配置
+
+通过环境变量定制运行时行为：
+
+| 变量名 | 说明 | 默认值 |
+| --- | --- | --- |
+| `PORT` | HTTP 服务监听端口 | `3000` |
+| `WAN_SPACE_BASE` | Hugging Face Space API 基础地址 | `https://huggingface.co/spaces/Wan-AI/Wan2.2-Animate` |
+| `WAN_API_TOKEN` | Hugging Face 访问令牌（若 Space 为私有或需更高额度） | 空 |
+| `WAN_DEFAULT_MODEL_ID` | 默认模式（Move / Mix） | `wan2.2-animate-move` |
+| `WAN_DEFAULT_MODEL_QUALITY` | 默认推理质量（Pro / Standard） | `wan-pro` |
+| `WAN_MOCK_MODE` | 开启后跳过真实推理并返回占位视频 | `false` |
+
+当禁用 `WAN_MOCK_MODE` 时，请确保网络可访问 Hugging Face 并提供合规的 Token。后端会将上传文件转换为临时数据并调用 `/api/upload/` 与 `/api/predict/` 接口，随后下载生成视频返回给前端。
+
+## 测试策略
+
+- **单元测试**：基于 Node.js 原生 `node:test` 框架，覆盖数据 URL 解析、文件大小格式化以及推理请求负载构造等关键工具函数。
+- **端到端测试**：启动实际的 HTTP 服务器（启用 Mock 模式），使用内联的媒体占位符数据模拟用户流程，验证从首页加载到生成结果的完整链路。
+
+## 目录结构
+
+```
+├── public/              # 前端静态资源（HTML、JS、Tailwind CDN）
+├── server/              # 轻量 Node.js 后端与工具方法
+├── tests/               # 单元与端到端测试（node:test）
+├── server.js            # 应用入口
+└── package.json
+```
+
+## 开发提示
+
+- 前端通过 FileReader 将媒体文件编码为 Data URL，再由后端解码并调用模型 API。
+- 后端默认使用内存缓存静态文件，减轻重复文件读取的成本。
+- Mock 模式返回占位视频数据，方便在无外网或无 Token 环境下验证流程。
+
+欢迎在真实推理环境中扩展体验，例如增加任务队列、历史记录或更丰富的错误处理。期待你的创意！

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "momentswap",
+  "version": "0.1.0",
+  "description": "MomentSwap - Wan-AI/Wan2.2-Animate face swapping MVP",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node server.js",
+    "test": "node --test tests/unit",
+    "test:e2e": "WAN_MOCK_MODE=true node --test tests/e2e",
+    "test:all": "npm run test && npm run test:e2e"
+  },
+  "keywords": [
+    "wan",
+    "huggingface",
+    "video",
+    "face-swap"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>瞬时变身 · MomentSwap</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-slate-950 text-white min-h-screen">
+    <header class="bg-slate-900 border-b border-slate-800">
+      <div class="max-w-5xl mx-auto px-4 py-6">
+        <h1 class="text-3xl font-semibold">瞬时变身（MomentSwap）</h1>
+        <p class="text-slate-300 mt-2">
+          使用 Wan-AI/Wan2.2-Animate 模型，将任意面孔替换到短视频中的人物上。
+        </p>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8 space-y-8">
+      <section class="grid gap-6 md:grid-cols-2">
+        <article class="bg-slate-900 border border-slate-800 rounded-xl p-6 space-y-4">
+          <h2 class="text-xl font-medium">上传素材</h2>
+          <form id="generateForm" class="space-y-6">
+            <div>
+              <label class="block text-sm font-medium text-slate-300" for="refImageInput">
+                目标面孔图片（JPG/PNG）
+              </label>
+              <input
+                type="file"
+                id="refImageInput"
+                name="refImage"
+                accept="image/*"
+                class="mt-2 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2"
+                required
+              />
+              <p class="text-xs text-slate-500 mt-1">请确保图像为清晰正面肖像。</p>
+              <img id="refPreview" alt="面孔预览" class="hidden mt-3 w-40 h-40 object-cover rounded-lg border border-slate-800" />
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-slate-300" for="sourceVideoInput">
+                源视频（5-10 秒 MP4/MOV）
+              </label>
+              <input
+                type="file"
+                id="sourceVideoInput"
+                name="sourceVideo"
+                accept="video/mp4,video/quicktime,video/*"
+                class="mt-2 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2"
+                required
+              />
+              <p class="text-xs text-slate-500 mt-1">建议选择单人短视频，避免复杂背景。</p>
+              <video id="videoPreview" class="hidden mt-3 w-full rounded-lg border border-slate-800" controls></video>
+            </div>
+
+            <div class="grid gap-4 md:grid-cols-2">
+              <label class="block text-sm">
+                <span class="text-slate-300">模式</span>
+                <select id="modelMode" class="mt-2 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2">
+                  <option value="wan2.2-animate-move">Move（默认）</option>
+                  <option value="wan2.2-animate-mix">Mix</option>
+                </select>
+              </label>
+              <label class="block text-sm">
+                <span class="text-slate-300">推理质量</span>
+                <select id="modelQuality" class="mt-2 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2">
+                  <option value="wan-pro">Pro（默认）</option>
+                  <option value="wan-std">Standard</option>
+                </select>
+              </label>
+            </div>
+
+            <button
+              type="submit"
+              class="w-full bg-violet-600 hover:bg-violet-500 transition-colors font-semibold py-3 rounded-lg"
+            >
+              开始生成
+            </button>
+          </form>
+        </article>
+
+        <article class="bg-slate-900 border border-slate-800 rounded-xl p-6 space-y-4">
+          <h2 class="text-xl font-medium">进度与结果</h2>
+          <div id="statusPanel" class="space-y-3 text-sm text-slate-300">
+            <p id="statusMessage">等待输入...</p>
+            <div id="progressIndicator" class="hidden">
+              <div class="flex items-center gap-3">
+                <span class="inline-flex h-3 w-3 animate-ping rounded-full bg-violet-400"></span>
+                <span>模型正在处理，大约需要 30-60 秒。</span>
+              </div>
+            </div>
+          </div>
+          <video id="resultVideo" class="hidden w-full rounded-lg border border-slate-800" controls></video>
+          <a
+            id="downloadButton"
+            href="#"
+            download="momentswap.mp4"
+            class="hidden inline-flex items-center justify-center px-4 py-2 rounded-lg border border-violet-500 text-violet-300 hover:bg-violet-500/20"
+          >
+            下载生成视频
+          </a>
+        </article>
+      </section>
+
+      <section class="bg-slate-900 border border-slate-800 rounded-xl p-6 space-y-3 text-sm text-slate-300">
+        <h2 class="text-lg font-medium text-white">使用提示</h2>
+        <ul class="list-disc list-inside space-y-2">
+          <li>上传的视频应为单人镜头，面部清晰可见。</li>
+          <li>确保目标面孔图片光照均匀，无夸张表情，以获得更稳定的结果。</li>
+          <li>生成结果仅作娱乐用途，请尊重肖像权与隐私。</li>
+        </ul>
+      </section>
+    </main>
+
+    <footer class="py-8 text-center text-xs text-slate-600">
+      © 2025 MomentSwap · Wan-AI/Wan2.2-Animate 概念验证
+    </footer>
+
+    <script src="./script.js" defer></script>
+  </body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,167 @@
+const form = document.getElementById('generateForm');
+const refInput = document.getElementById('refImageInput');
+const videoInput = document.getElementById('sourceVideoInput');
+const refPreview = document.getElementById('refPreview');
+const videoPreview = document.getElementById('videoPreview');
+const statusMessage = document.getElementById('statusMessage');
+const progressIndicator = document.getElementById('progressIndicator');
+const resultVideo = document.getElementById('resultVideo');
+const downloadButton = document.getElementById('downloadButton');
+const modelMode = document.getElementById('modelMode');
+const modelQuality = document.getElementById('modelQuality');
+
+let activeObjectUrl = null;
+
+function setStatus(message) {
+  statusMessage.textContent = message;
+}
+
+function toggleProgress(visible) {
+  progressIndicator.classList.toggle('hidden', !visible);
+}
+
+function showPreview(element, file) {
+  if (!file) {
+    element.classList.add('hidden');
+    element.removeAttribute('src');
+    return;
+  }
+  const url = URL.createObjectURL(file);
+  element.src = url;
+  element.classList.remove('hidden');
+  element.dataset.previewUrl = url;
+}
+
+refInput.addEventListener('change', () => {
+  const [file] = refInput.files;
+  if (file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      refPreview.src = reader.result;
+      refPreview.classList.remove('hidden');
+    };
+    reader.readAsDataURL(file);
+  } else {
+    refPreview.classList.add('hidden');
+  }
+});
+
+videoInput.addEventListener('change', () => {
+  const [file] = videoInput.files;
+  if (file) {
+    showPreview(videoPreview, file);
+  } else {
+    videoPreview.classList.add('hidden');
+    videoPreview.removeAttribute('src');
+  }
+});
+
+function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error || new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+function revokeActiveObjectUrl() {
+  if (activeObjectUrl) {
+    URL.revokeObjectURL(activeObjectUrl);
+    activeObjectUrl = null;
+  }
+}
+
+function base64ToBlob(base64, contentType) {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: contentType });
+}
+
+async function submitForm(event) {
+  event.preventDefault();
+  const [refFile] = refInput.files;
+  const [videoFile] = videoInput.files;
+  if (!refFile || !videoFile) {
+    setStatus('请先选择面孔图片和源视频。');
+    return;
+  }
+
+  revokeActiveObjectUrl();
+  toggleProgress(true);
+  setStatus('正在上传素材并启动模型...');
+  downloadButton.classList.add('hidden');
+  resultVideo.classList.add('hidden');
+
+  try {
+    const [refDataUrl, videoDataUrl] = await Promise.all([
+      readFileAsDataUrl(refFile),
+      readFileAsDataUrl(videoFile)
+    ]);
+
+    const payload = {
+      refImage: {
+        name: refFile.name,
+        type: refFile.type,
+        size: refFile.size,
+        dataUrl: refDataUrl
+      },
+      sourceVideo: {
+        name: videoFile.name,
+        type: videoFile.type,
+        size: videoFile.size,
+        dataUrl: videoDataUrl
+      },
+      options: {
+        modelId: modelMode.value,
+        modelQuality: modelQuality.value
+      }
+    };
+
+    const response = await fetch('/api/generate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      throw new Error(`服务器返回错误：${response.status}`);
+    }
+
+    const result = await response.json();
+    if (result.error) {
+      throw new Error(result.error);
+    }
+
+    const videoBlob = base64ToBlob(result.video.data, result.video.contentType);
+    const objectUrl = URL.createObjectURL(videoBlob);
+    activeObjectUrl = objectUrl;
+    resultVideo.src = objectUrl;
+    resultVideo.classList.remove('hidden');
+    downloadButton.href = objectUrl;
+    downloadButton.classList.remove('hidden');
+    setStatus(result.message || '生成完成！');
+  } catch (error) {
+    console.error(error);
+    setStatus(error.message || '生成失败，请稍后重试。');
+  } finally {
+    toggleProgress(false);
+  }
+}
+
+form.addEventListener('submit', submitForm);
+
+window.addEventListener('beforeunload', () => {
+  revokeActiveObjectUrl();
+  if (refPreview.dataset.previewUrl) {
+    URL.revokeObjectURL(refPreview.dataset.previewUrl);
+  }
+  if (videoPreview.dataset.previewUrl) {
+    URL.revokeObjectURL(videoPreview.dataset.previewUrl);
+  }
+});

--- a/server.js
+++ b/server.js
@@ -1,0 +1,3 @@
+const { startServer } = require('./server/index.js');
+
+startServer();

--- a/server/config.js
+++ b/server/config.js
@@ -1,0 +1,20 @@
+const path = require('node:path');
+
+const DEFAULT_SPACE_BASE = 'https://huggingface.co/spaces/Wan-AI/Wan2.2-Animate';
+
+function resolveBoolean(value) {
+  if (typeof value === 'string') {
+    return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+  }
+  return Boolean(value);
+}
+
+module.exports = {
+  PORT: Number(process.env.PORT) || 3000,
+  WAN_SPACE_BASE: process.env.WAN_SPACE_BASE || DEFAULT_SPACE_BASE,
+  WAN_API_TOKEN: process.env.WAN_API_TOKEN || '',
+  WAN_DEFAULT_MODEL_ID: process.env.WAN_DEFAULT_MODEL_ID || 'wan2.2-animate-move',
+  WAN_DEFAULT_MODEL_QUALITY: process.env.WAN_DEFAULT_MODEL_QUALITY || 'wan-pro',
+  PUBLIC_DIR: path.join(__dirname, '..', 'public'),
+  MOCK_MODE: resolveBoolean(process.env.WAN_MOCK_MODE)
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,152 @@
+const http = require('node:http');
+const fsp = require('node:fs/promises');
+const path = require('node:path');
+const { URL } = require('node:url');
+const { PORT, PUBLIC_DIR, MOCK_MODE } = require('./config');
+const { decodeDataUrl } = require('./utils/dataUrl');
+const { formatFileSize } = require('./utils/file');
+const { generateSwap } = require('./services/wanService');
+
+const STATIC_FILES = new Map();
+
+function getContentType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.js':
+      return 'text/javascript; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.svg':
+      return 'image/svg+xml';
+    case '.mp4':
+      return 'video/mp4';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+async function serveStaticFile(filePath, res) {
+  try {
+    let content = STATIC_FILES.get(filePath);
+    if (!content) {
+      content = await fsp.readFile(filePath);
+      STATIC_FILES.set(filePath, content);
+    }
+    res.writeHead(200, { 'Content-Type': getContentType(filePath) });
+    res.end(content);
+  } catch (error) {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not Found' }));
+  }
+}
+
+async function readJsonBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  const bodyString = Buffer.concat(chunks).toString('utf-8');
+  return JSON.parse(bodyString || '{}');
+}
+
+const MOCK_VIDEO_BASE64 = Buffer.from('MomentSwap mock video placeholder').toString('base64');
+
+async function handleGenerate(req, res) {
+  try {
+    const body = await readJsonBody(req);
+    const { refImage, sourceVideo, options = {} } = body;
+    if (!refImage?.dataUrl || !sourceVideo?.dataUrl) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Missing media payloads' }));
+      return;
+    }
+
+    const reference = decodeDataUrl(refImage.dataUrl);
+    const video = decodeDataUrl(sourceVideo.dataUrl);
+
+    if (MOCK_MODE) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        status: 'success',
+        message: 'Mock generation completed',
+        video: {
+          contentType: 'video/mp4',
+          data: MOCK_VIDEO_BASE64
+        }
+      }));
+      return;
+    }
+
+    const swapResult = await generateSwap({
+      referenceBuffer: reference.buffer,
+      referenceName: refImage.name || 'reference.png',
+      referenceMime: refImage.type || reference.mimeType,
+      videoBuffer: video.buffer,
+      videoName: sourceVideo.name || 'source.mp4',
+      videoMime: sourceVideo.type || video.mimeType,
+      options
+    });
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      status: 'success',
+      message: swapResult.statusMessage,
+      video: {
+        contentType: swapResult.contentType,
+        data: swapResult.buffer.toString('base64')
+      }
+    }));
+  } catch (error) {
+    console.error('Generation failed', error);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: error.message || 'Generation failed' }));
+  }
+}
+
+function createServer() {
+  return http.createServer(async (req, res) => {
+    const requestUrl = new URL(req.url, `http://${req.headers.host}`);
+    if (req.method === 'GET' && (requestUrl.pathname === '/' || requestUrl.pathname === '/index.html')) {
+      const filePath = path.join(PUBLIC_DIR, 'index.html');
+      await serveStaticFile(filePath, res);
+      return;
+    }
+
+    if (req.method === 'GET') {
+      const filePath = path.join(PUBLIC_DIR, requestUrl.pathname);
+      if (filePath.startsWith(PUBLIC_DIR)) {
+        await serveStaticFile(filePath, res);
+        return;
+      }
+    }
+
+    if (req.method === 'POST' && requestUrl.pathname === '/api/generate') {
+      await handleGenerate(req, res);
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not Found' }));
+  });
+}
+
+function startServer(port = PORT) {
+  const server = createServer();
+  server.listen(port, () => {
+    console.log(`MomentSwap server listening on http://localhost:${port}`);
+  });
+  return server;
+}
+
+module.exports = {
+  createServer,
+  startServer,
+  formatFileSize
+};

--- a/server/services/wanService.js
+++ b/server/services/wanService.js
@@ -1,0 +1,126 @@
+const { WAN_SPACE_BASE, WAN_API_TOKEN, WAN_DEFAULT_MODEL_ID, WAN_DEFAULT_MODEL_QUALITY } = require('../config');
+
+const UPLOAD_ENDPOINT = new URL('/api/upload/', WAN_SPACE_BASE);
+const PREDICT_ENDPOINT = new URL('/api/predict/', WAN_SPACE_BASE);
+const FILE_ENDPOINT = new URL('/api/file/', WAN_SPACE_BASE);
+
+function authHeaders() {
+  return WAN_API_TOKEN
+    ? { Authorization: `Bearer ${WAN_API_TOKEN}` }
+    : {};
+}
+
+async function uploadAsset({ buffer, filename, mimeType }) {
+  const formData = new FormData();
+  const blob = new Blob([buffer], { type: mimeType });
+  formData.append('files', blob, filename);
+  formData.append('file', blob, filename);
+
+  const response = await fetch(UPLOAD_ENDPOINT, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: formData
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Upload failed: ${response.status} ${text}`);
+  }
+
+  const payload = await response.json();
+  if (payload?.length) {
+    return payload[0];
+  }
+  if (payload?.path) {
+    return payload;
+  }
+  throw new Error('Unexpected upload response shape');
+}
+
+function buildPredictPayload(referenceFile, videoFile, options = {}) {
+  const modelId = options.modelId || WAN_DEFAULT_MODEL_ID;
+  const quality = options.modelQuality || WAN_DEFAULT_MODEL_QUALITY;
+  return {
+    data: [
+      referenceFile,
+      { video: videoFile, subtitles: null },
+      modelId,
+      quality
+    ]
+  };
+}
+
+async function requestPrediction(referenceFile, videoFile, options = {}) {
+  const payload = buildPredictPayload(referenceFile, videoFile, options);
+  const response = await fetch(PREDICT_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders()
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Prediction failed: ${response.status} ${text}`);
+  }
+
+  const json = await response.json();
+  const data = Array.isArray(json?.data) ? json.data : [];
+  const result = data[0];
+  const statusMessage = data[1] || json?.status || 'Completed';
+
+  if (!result || !result.video) {
+    throw new Error('Prediction did not return a video result');
+  }
+
+  return { result, statusMessage };
+}
+
+async function downloadResult(videoResult) {
+  const videoInfo = videoResult.video || videoResult;
+  if (!videoInfo.path) {
+    throw new Error('Video result is missing a path');
+  }
+  const fileUrl = new URL(FILE_ENDPOINT);
+  fileUrl.searchParams.set('path', videoInfo.path);
+
+  const response = await fetch(fileUrl, {
+    method: 'GET',
+    headers: authHeaders()
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to download generated video: ${response.status} ${text}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+async function generateSwap({ referenceBuffer, referenceName, referenceMime, videoBuffer, videoName, videoMime, options }) {
+  const referenceUpload = await uploadAsset({
+    buffer: referenceBuffer,
+    filename: referenceName,
+    mimeType: referenceMime
+  });
+  const videoUpload = await uploadAsset({
+    buffer: videoBuffer,
+    filename: videoName,
+    mimeType: videoMime
+  });
+
+  const { result, statusMessage } = await requestPrediction(referenceUpload, videoUpload, options);
+  const videoBinary = await downloadResult(result);
+  return {
+    buffer: videoBinary,
+    contentType: result?.video?.mime_type || 'video/mp4',
+    statusMessage
+  };
+}
+
+module.exports = {
+  generateSwap,
+  buildPredictPayload
+};

--- a/server/utils/dataUrl.js
+++ b/server/utils/dataUrl.js
@@ -1,0 +1,25 @@
+const assert = require('node:assert');
+
+function decodeDataUrl(dataUrl) {
+  if (typeof dataUrl !== 'string') {
+    throw new TypeError('Expected data URL string');
+  }
+  const match = dataUrl.match(/^data:([^;,]+);base64,(.+)$/);
+  assert(match, 'Invalid data URL format');
+  const [, mimeType, base64Data] = match;
+  const buffer = Buffer.from(base64Data, 'base64');
+  return { mimeType, buffer };
+}
+
+function bufferToDataUrl(buffer, mimeType) {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new TypeError('Expected buffer');
+  }
+  const base64 = buffer.toString('base64');
+  return `data:${mimeType};base64,${base64}`;
+}
+
+module.exports = {
+  decodeDataUrl,
+  bufferToDataUrl
+};

--- a/server/utils/file.js
+++ b/server/utils/file.js
@@ -1,0 +1,20 @@
+function formatFileSize(bytes) {
+  if (typeof bytes !== 'number' || Number.isNaN(bytes)) {
+    throw new TypeError('Expected number of bytes');
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ['KB', 'MB', 'GB'];
+  let size = bytes;
+  let unitIndex = -1;
+  do {
+    size /= 1024;
+    unitIndex += 1;
+  } while (size >= 1024 && unitIndex < units.length - 1);
+  return `${size.toFixed(1)} ${units[unitIndex]}`;
+}
+
+module.exports = {
+  formatFileSize
+};

--- a/tests/e2e/app.test.js
+++ b/tests/e2e/app.test.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { bufferToDataUrl } = require('../../server/utils/dataUrl');
+const { createServer } = require('../../server/index.js');
+
+async function startServer() {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  return { server, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+test('end-to-end generation flow (mock mode)', async (t) => {
+  const { server, baseUrl } = await startServer();
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  const indexResponse = await fetch(baseUrl);
+  assert.strictEqual(indexResponse.status, 200);
+  const html = await indexResponse.text();
+  assert.match(html, /MomentSwap/);
+
+  const imageBuffer = Buffer.from('fake image data for testing');
+  const videoBuffer = Buffer.from('fake video data for testing');
+
+  const payload = {
+    refImage: {
+      name: 'test-face.png',
+      type: 'image/png',
+      dataUrl: bufferToDataUrl(imageBuffer, 'image/png')
+    },
+    sourceVideo: {
+      name: 'test-video.mp4',
+      type: 'video/mp4',
+      dataUrl: bufferToDataUrl(videoBuffer, 'video/mp4')
+    },
+    options: {
+      modelId: 'wan2.2-animate-move',
+      modelQuality: 'wan-pro'
+    }
+  };
+
+  const response = await fetch(`${baseUrl}/api/generate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+
+  assert.strictEqual(response.status, 200);
+  const result = await response.json();
+  assert.strictEqual(result.status, 'success');
+  assert.ok(result.video?.data);
+  assert.ok(result.video?.contentType.includes('video'));
+});

--- a/tests/unit/dataUrl.test.js
+++ b/tests/unit/dataUrl.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { decodeDataUrl, bufferToDataUrl } = require('../../server/utils/dataUrl');
+
+const SAMPLE_DATA_URL = 'data:text/plain;base64,SGVsbG8=';
+
+test('decodeDataUrl returns buffer and mime type', () => {
+  const { buffer, mimeType } = decodeDataUrl(SAMPLE_DATA_URL);
+  assert.strictEqual(mimeType, 'text/plain');
+  assert.strictEqual(buffer.toString('utf-8'), 'Hello');
+});
+
+test('bufferToDataUrl encodes buffer to data url', () => {
+  const buffer = Buffer.from('World', 'utf-8');
+  const dataUrl = bufferToDataUrl(buffer, 'text/plain');
+  assert.strictEqual(dataUrl, 'data:text/plain;base64,V29ybGQ=');
+});
+
+test('decodeDataUrl throws on invalid input', () => {
+  assert.throws(() => decodeDataUrl('invalid'), /Invalid data URL/);
+});

--- a/tests/unit/fileUtils.test.js
+++ b/tests/unit/fileUtils.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { formatFileSize } = require('../../server/utils/file');
+
+test('formatFileSize handles bytes under 1KB', () => {
+  assert.strictEqual(formatFileSize(512), '512 B');
+});
+
+test('formatFileSize converts to KB and MB', () => {
+  assert.strictEqual(formatFileSize(2048), '2.0 KB');
+  assert.strictEqual(formatFileSize(1048576), '1.0 MB');
+});
+
+test('formatFileSize throws on invalid input', () => {
+  assert.throws(() => formatFileSize('abc'), /Expected number of bytes/);
+});

--- a/tests/unit/wanService.test.js
+++ b/tests/unit/wanService.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { buildPredictPayload } = require('../../server/services/wanService');
+
+test('buildPredictPayload arranges inputs correctly', () => {
+  const ref = { path: '/tmp/ref.png' };
+  const video = { path: '/tmp/video.mp4', mime_type: 'video/mp4' };
+  const payload = buildPredictPayload(ref, video, { modelId: 'wan2.2-animate-mix', modelQuality: 'wan-std' });
+  assert.deepStrictEqual(payload, {
+    data: [
+      ref,
+      { video, subtitles: null },
+      'wan2.2-animate-mix',
+      'wan-std'
+    ]
+  });
+});


### PR DESCRIPTION
## Summary
- remove binary media fixtures from the repo and rely on inline mock payloads for the e2e flow
- update the server mock mode to emit an in-memory placeholder clip and document the new approach

## Testing
- npm test
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68dbaacdf6688324b6821703134d8db1